### PR TITLE
Set scope=provided

### DIFF
--- a/feign-hystrix-opentracing/pom.xml
+++ b/feign-hystrix-opentracing/pom.xml
@@ -23,6 +23,7 @@
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-hystrix</artifactId>
       <version>${version.io.github.openfeign}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/feign-opentracing/pom.xml
+++ b/feign-opentracing/pom.xml
@@ -23,6 +23,7 @@
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-core</artifactId>
       <version>${version.io.github.openfeign}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.