### PR TITLE
Handle unmodifiable collections during header injection

### DIFF
--- a/feign-opentracing/src/main/java/feign/opentracing/HttpHeadersInjectAdapter.java
+++ b/feign-opentracing/src/main/java/feign/opentracing/HttpHeadersInjectAdapter.java
@@ -2,8 +2,11 @@ package feign.opentracing;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.opentracing.propagation.TextMap;
 
@@ -32,7 +35,23 @@ class HttpHeadersInjectAdapter implements TextMap {
             headers.put(key, values);
         }
 
-        values.add(value);
+        try {
+            values.add(value);
+        } catch (UnsupportedOperationException ex) {
+            if (values instanceof List) {
+                // Handle unmodifiable Lists
+                List<String> list = new ArrayList<>(values);
+                list.add(value);
+                headers.put(key, list);
+            } else if (values instanceof Set) {
+                // Handle unmodifiable Sets
+                Set<String> set = new HashSet<>(values);
+                set.add(value);
+                headers.put(key, set);
+            } else {
+                throw ex;
+            }
+        }
     }
 
     @Override

--- a/feign-opentracing/src/test/java/feign/opentracing/HttpHeadersInjectAdapterTest.java
+++ b/feign-opentracing/src/test/java/feign/opentracing/HttpHeadersInjectAdapterTest.java
@@ -1,0 +1,48 @@
+package feign.opentracing;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class HttpHeadersInjectAdapterTest {
+
+    @Test
+    public void putNewTraceHeaderValueInsideList() {
+        Map<String, Collection<String>> headers = new HashMap<>();
+        headers.put("x-header", Arrays.asList("123:123:123:1"));
+        HttpHeadersInjectAdapter adapter = new HttpHeadersInjectAdapter(headers);
+
+        adapter.put("x-header", "123:456:456:1");
+
+        assertEquals(headers.get("x-header"), Arrays.asList("123:123:123:1", "123:456:456:1"));
+    }
+
+    @Test
+    public void putNewTraceHeaderValueInsideUnmodifiableList() {
+        Map<String, Collection<String>> headers = new HashMap<>();
+        headers.put("x-header", Collections.unmodifiableList(Arrays.asList("123:123:123:1")));
+        HttpHeadersInjectAdapter adapter = new HttpHeadersInjectAdapter(headers);
+
+        adapter.put("x-header", "123:456:456:1");
+
+        assertEquals(headers.get("x-header"), Arrays.asList("123:123:123:1", "123:456:456:1"));
+    }
+
+    @Test
+    public void putNewTraceHeaderValueInsideUnmodifiableSet() {
+        Map<String, Collection<String>> headers = new HashMap<>();
+        headers.put("x-header", Collections.unmodifiableSet(new HashSet<>(Arrays.asList("123:123:123:1"))));
+        HttpHeadersInjectAdapter adapter = new HttpHeadersInjectAdapter(headers);
+
+        adapter.put("x-header", "123:456:456:1");
+
+        assertEquals(headers.get("x-header"), new HashSet<>(Arrays.asList("123:123:123:1", "123:456:456:1")));
+    }
+}


### PR DESCRIPTION
The Spring integration libraries such as `opentracing-spring-cloud-starter` and `opentracing-spring-jaeger-cloud-starter` provide HTTP requests bodies that contain headers with `UnmodifiableCollection`, which makes the Header injection fail with an `UnsupportedOperationException` and the message `Error when injecting SpanContext into carrier. Handling gracefully.`

This PR provides the necessary code to handle cleanly Unmodifiable collections and allows those integrations to work as expected. 

If this change could be checked and, if acceptable, released as soon as possible that would great, since we need this to be able to use Jaeger with the latest versions of Spring Boot.