### PR TITLE
added missing requestTemplate data on copy

### DIFF
--- a/feign-opentracing/src/main/java/feign/opentracing/TracingClient.java
+++ b/feign-opentracing/src/main/java/feign/opentracing/TracingClient.java
@@ -97,7 +97,7 @@ public class TracingClient implements Client {
     private Request inject(SpanContext spanContext, Request request) {
         Map<String, Collection<String>> headersWithTracingContext = new HashMap<>(request.headers());
         tracer.inject(spanContext, Format.Builtin.HTTP_HEADERS, new HttpHeadersInjectAdapter(headersWithTracingContext));
-        return request.create(request.method(), request.url(), headersWithTracingContext,request.body(),
-                request.charset());
+        return Request.create(request.httpMethod(), request.url(), headersWithTracingContext,request.body(),
+                request.charset(), request.requestTemplate());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
     <version.com.squareup.okhttp3-mockwebserver>3.6.0</version.com.squareup.okhttp3-mockwebserver>
-    <version.io.github.openfeign>10.2.0</version.io.github.openfeign>
+    <version.io.github.openfeign>10.12</version.io.github.openfeign>
     <version.io.opentracing>0.33.0</version.io.opentracing>
     <version.junit>4.13.1</version.junit>
 


### PR DESCRIPTION
this PR replaces static usage of Request.create with the non-deprecated variant, also to not loose requestTemplate information. 
This is necessary, otherwise the lib wont work together with e.g. feign-micrometer (which relies on requestTemplate)